### PR TITLE
Keycloak integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV KUBE_LATEST_VERSION=v1.14.1
 ENV HELM_VERSION=v2.14.1
 ENV HELM_FILENAME=helm-${HELM_VERSION}-linux-amd64.tar.gz
 
+# pyopenssl needed to generate key/certificate for rancher/keycloak integration
 RUN echo "===> Add docker..."  && \
     apk --update --no-cache add docker && \
     echo "===> Add build dependencies..."  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "===> Add docker..."  && \
     \
     echo "===> Installing python packages..."  && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir ansible docker-py cloudbridge && \
+    pip install --no-cache-dir ansible docker-py pyopenssl cloudbridge && \
     \
     echo "==> Installing latest kubectl and helm..." && \
     apk add --no-cache curl && \

--- a/roles/rancher/files/hostPath_storageClass.yaml
+++ b/roles/rancher/files/hostPath_storageClass.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "persistentvolumes", "pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+      - name: local-path-provisioner
+        image: rancher/local-path-provisioner:v0.0.9
+        imagePullPolicy: Always
+        command:
+        - local-path-provisioner
+        - --debug
+        - start
+        - --config
+        - /etc/config/config.json
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config/
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-provisioner
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+        {
+                "nodePathMap":[
+                {
+                        "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                        "paths":["/opt/local-path-provisioner"]
+                }
+                ]
+        }

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -131,48 +131,6 @@
         ingress:
           provider: nginx
           type: ingressConfig
-        services:
-          type: "/v3/schemas/rkeConfigServices"
-          kubeApi:
-            type: "/v3/schemas/kubeAPIService"
-            extraArgs:
-              feature-gates: "TTLAfterFinished=true"
-          kubeController:
-            type: "/v3/schemas/kubeControllerService"
-            extraArgs:
-              feature-gates: "TTLAfterFinished=true"
-          kubelet:
-            type: "/v3/schemas/kubeletService"
-            extraArgs:
-              feature-gates: "TTLAfterFinished=true"
-          kubeproxy:
-            type: "/v3/schemas/kubeproxyService"
-            extraArgs:
-              feature-gates: "TTLAfterFinished=true"
-          scheduler:
-            type: "/v3/schemas/schedulerService"
-            extraArgs:
-              feature-gates: "TTLAfterFinished=true"
-    headers:
-      Authorization: Bearer {{ token }}
-    validate_certs: no
-    status_code: 201
-  register: cluster
-  when: not cluster_id is defined and not kube_cloud_provider
-
-- name: Create a cluster
-  uri:
-    url: https://{{ rancher_server }}:{{ rancher_port }}/v3/cluster
-    method: POST
-    body_format: json
-    body:
-      type: cluster
-      name: "{{ cm_cluster_name }}"
-      rancherKubernetesEngineConfig:
-        ignoreDockerVersion: true
-        ingress:
-          provider: nginx
-          type: ingressConfig
         cloudProvider:
           name: "{{ kube_cloud_provider }}"
           customCloudProvider: |-
@@ -207,6 +165,48 @@
     status_code: 201
   register: cluster
   when: not cluster_id is defined and kube_cloud_provider
+
+- name: Create a cluster
+  uri:
+    url: https://{{ rancher_server }}:{{ rancher_port }}/v3/cluster
+    method: POST
+    body_format: json
+    body:
+      type: cluster
+      name: "{{ cm_cluster_name }}"
+      rancherKubernetesEngineConfig:
+        ignoreDockerVersion: true
+        ingress:
+          provider: nginx
+          type: ingressConfig
+        services:
+          type: "/v3/schemas/rkeConfigServices"
+          kubeApi:
+            type: "/v3/schemas/kubeAPIService"
+            extraArgs:
+              feature-gates: "TTLAfterFinished=true"
+          kubeController:
+            type: "/v3/schemas/kubeControllerService"
+            extraArgs:
+              feature-gates: "TTLAfterFinished=true"
+          kubelet:
+            type: "/v3/schemas/kubeletService"
+            extraArgs:
+              feature-gates: "TTLAfterFinished=true"
+          kubeproxy:
+            type: "/v3/schemas/kubeproxyService"
+            extraArgs:
+              feature-gates: "TTLAfterFinished=true"
+          scheduler:
+            type: "/v3/schemas/schedulerService"
+            extraArgs:
+              feature-gates: "TTLAfterFinished=true"
+    headers:
+      Authorization: Bearer {{ token }}
+    validate_certs: no
+    status_code: 201
+  register: cluster
+  when: not cluster_id is defined and not kube_cloud_provider
 
 - name: Store new cluster id
   set_fact:
@@ -470,7 +470,7 @@
   delay: 2
 
 - name: Add CloudVE Helm repo
-  shell: /usr/local/bin/helm repo add galaxyproject https://raw.githubusercontent.com/CloudVE/helm-charts/master/
+  shell: /usr/local/bin/helm repo add galaxyproject https://raw.githubusercontent.com/cloudve/helm-charts/master/
 
 - name: Update Helm repos
   shell: /usr/local/bin/helm repo update
@@ -704,6 +704,229 @@
   set_fact:
     svc_access_line: "Login to any of these services as user 'admin', using the password you supplied."
   when: using_random_pwd is not defined
+
+- name: Login to KeyCloak
+  uri:
+    url: "https://{{ rancher_server }}/auth/realms/master/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      client_id: admin-cli
+      grant_type: password
+      username: admin
+      password: "{{ rancher_password }}"
+    validate_certs: no
+    return_content: yes
+  register: kc_login_response
+  until: kc_login_response['status']
+  retries: 5
+  delay: 10
+
+- name: Set KeyCloak Token
+  set_fact:
+    kc_token: "{{ kc_login_response.json.access_token }}"
+
+- name: Create KeyCloak SAML Client
+  uri:
+    url: "https://{{ rancher_server }}/auth/admin/realms/master/clients"
+    method: POST
+    body_format: json
+    body:
+      clientId: "https://{{ rancher_server }}:{{ rancher_port }}/v1-saml/keycloak/saml/metadata"
+      name: "rancher"
+      protocol: "saml"
+      frontchannelLogout: false
+      redirectUris: ["https://{{ rancher_server }}:{{ rancher_port }}/v1-saml/keycloak/saml/acs"]
+      attributes: { "saml.authnstatement": false, "saml.client.signature": false, "saml.force.post.binding": false, "saml.server.signature": true}
+    validate_certs: no
+    status_code: 201
+    headers:
+      Authorization: Bearer {{ kc_token }}
+    return_content: yes
+  register: kc_client_response
+  retries: 5
+  delay: 10
+
+- name: Create cn mapping
+  uri:
+    url: "{{ kc_client_response.location }}/protocol-mappers/models"
+    method: POST
+    body_format: json
+    body:
+      config:
+        user.attribute: "username"
+        friendly.name: ""
+        attribute.name: "cn"
+        attribute.nameformat: "Basic"
+      name: "username to cn"
+      protocol: "saml"
+      protocolMapper: "saml-user-property-mapper"
+    validate_certs: no
+    status_code: 201
+    headers:
+      Authorization: Bearer {{ kc_token }}
+  retries: 5
+  delay: 10
+
+- name: Create uid mapping
+  uri:
+    url: "{{ kc_client_response.location }}/protocol-mappers/models"
+    method: POST
+    body_format: json
+    body:
+      config:
+        user.attribute: "username"
+        friendly.name: ""
+        attribute.name: "uid"
+        attribute.nameformat: "Basic"
+      name: "username to uid"
+      protocol: "saml"
+      protocolMapper: "saml-user-property-mapper"
+    validate_certs: no
+    status_code: 201
+    headers:
+      Authorization: Bearer {{ kc_token }}
+  retries: 5
+  delay: 10
+
+- name: Create displayName mapping
+  uri:
+    url: "{{ kc_client_response.location }}/protocol-mappers/models"
+    method: POST
+    body_format: json
+    body:
+      config:
+        user.attribute: "firstName"
+        friendly.name: ""
+        attribute.name: "displayName"
+        attribute.nameformat: "Basic"
+      name: "firstName to displayName"
+      protocol: "saml"
+      protocolMapper: "saml-user-property-mapper"
+    validate_certs: no
+    status_code: 201
+    headers:
+      Authorization: Bearer {{ kc_token }}
+  retries: 5
+  delay: 10
+
+- name: Create Groups mapping
+  uri:
+    url: "{{ kc_client_response.location }}/protocol-mappers/models"
+    method: POST
+    body_format: json
+    body:
+      config:
+        attribute.name: "memberOf"
+        attribute.nameformat: "Basic"
+        friendly.name: ""
+        full.path: false
+        single: true
+      name: "Groups"
+      protocol: "saml"
+      protocolMapper: "saml-group-membership-mapper"
+    validate_certs: no
+    status_code: 201
+    headers:
+      Authorization: Bearer {{ kc_token }}
+  retries: 5
+  delay: 10
+
+- name: Get SAML Metadata IDPSSODescriptor
+  uri:
+    url: "{{ kc_client_response.location }}/installation/providers/saml-idp-descriptor"
+    method: GET
+    validate_certs: no
+    headers:
+      Authorization: Bearer {{ kc_token }}
+    return_content: yes
+  register: idp_metadata
+  retries: 5
+  delay: 10
+
+- name: Generate a key
+  openssl_privatekey:
+    path: /tmp/cm-boot/ansible-rancher.pem
+    size: 2048
+
+- name: Generate CSR
+  openssl_csr:
+    path: /tmp/cm-boot/ansible-rancher.csr
+    privatekey_path: /tmp/cm-boot/ansible-rancher.pem
+    common_name: ansible-rancher
+
+- name: Generate a Self Signed OpenSSL certificate
+  openssl_certificate:
+    path: /tmp/cm-boot/ansible-rancher.crt
+    privatekey_path: /tmp/cm-boot/ansible-rancher.pem
+    csr_path: /tmp/cm-boot/ansible-rancher.csr
+    provider: selfsigned
+
+- name: Set key and certificate
+  set_fact:
+    rancher_key: "{{ lookup('file', '/tmp/cm-boot/ansible-rancher.pem') }}"
+    rancher_cert: "{{ lookup('file', '/tmp/cm-boot/ansible-rancher.crt') }}"
+
+- name: Login to Rancher
+  uri:
+    url: "https://{{ rancher_server }}:{{ rancher_port }}/v3-public/localProviders/local?action=login"
+    method: POST
+    body_format: json
+    body:
+      username: admin
+      password: "{{ rancher_password }}"
+    validate_certs: no
+    status_code: 201
+    return_content: yes
+  register: rancher_login
+  retries: 5
+  delay: 10
+
+- name: Set Rancher Token
+  set_fact:
+    ra_token: "{{ rancher_login.json.token }}"
+
+- name: Setup Rancher External Auth
+  uri:
+    url: "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak"
+    method: PUT
+    validate_certs: no
+    body_format: json
+    body:
+      accessMode: "required"
+      actions: { "disable": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak?action=disable", "testAndEnable": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak?action=testAndEnable" }
+      allowedPrincipalIds: ["keycloak_user://admin"]
+      baseType: "authConfig"
+      displayNameField: "displayName"
+      enabled: true
+      groupsField: "memberOf"
+      id: "keycloak"
+      idpMetadataContent: '{{ idp_metadata.content }}'
+      links: { "self": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak", "update": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak" }
+      name: "keycloak"
+      rancherApiHost: "https://{{ rancher_server }}:{{ rancher_port }}/"
+      spCert: "{{ rancher_cert }}"
+      spKey: "{{ rancher_key }}"
+      type: "keyCloakConfig"
+      uidField: "uid"
+      userNameField: "cn"
+    headers:
+      Authorization: Bearer {{ ra_token }}
+  retries: 5
+  delay: 10
+
+- name: Set default Rancher user role to admin
+  uri:
+    url: "https://{{ rancher_server }}:{{ rancher_port }}/v3/globalRoles/admin"
+    method: PUT
+    validate_certs: no
+    body_format: json
+    body:
+      newUserDefault: true
+    headers:
+      Authorization: Bearer {{ ra_token }}
+  retries: 5
+  delay: 10
 
 - name: Wait for CloudMan login to become accessible
   uri:

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -475,6 +475,10 @@
 - name: Update Helm repos
   shell: /usr/local/bin/helm repo update
 
+- name: Fallback to hostPath provisioner when no cloud provider is set
+  shell: /usr/local/bin/kubectl apply -f https://gist.githubusercontent.com/almahmoud/92186a6521cde97f3680a85cf5202bdc/raw/16d08cc4abc2b3f87ab02dec2dd479e4e9fdbd41/fallback-cloudman-boot-storageclass.yaml
+  when: not kube_cloud_provider
+
 # Persistent Volumes are being added instead above
 - name: Check if nfs-provisioner app has been added
   uri:

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -476,7 +476,7 @@
   shell: /usr/local/bin/helm repo update
 
 - name: Fallback to hostPath provisioner when no cloud provider is set
-  shell: /usr/local/bin/kubectl apply -f https://gist.githubusercontent.com/almahmoud/92186a6521cde97f3680a85cf5202bdc/raw/16d08cc4abc2b3f87ab02dec2dd479e4e9fdbd41/fallback-cloudman-boot-storageclass.yaml
+  shell: /usr/local/bin/kubectl apply -f /tmp/cm-boot/roles/rancher/files/hostPath_storageClass.yaml
   when: not kube_cloud_provider
 
 # Persistent Volumes are being added instead above

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -939,7 +939,7 @@
     validate_certs: no
   register: cm_available
   until: cm_available['status']|default(0) == 200
-  retries: 40
+  retries: 60
   delay: 10
   when: cm_skip_cloudman is not defined or not (cm_skip_cloudman|bool)
 

--- a/scripts/cm_boot_linux.sh
+++ b/scripts/cm_boot_linux.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 HOST_NAME=${1:-127.0.0.1}
+if [ $HOST_NAME == '--use-public-ip' ]
+then
+   HOST_NAME=$(curl http://whatismyip.akamai.com)
+fi
 docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host galaxy/cloudman-boot

--- a/scripts/cm_boot_public_ip_linux.sh
+++ b/scripts/cm_boot_public_ip_linux.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+HOST_NAME=$(curl ifconfig.me)
+docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host galaxy/cloudman-boot

--- a/scripts/cm_boot_public_ip_linux.sh
+++ b/scripts/cm_boot_public_ip_linux.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-HOST_NAME=$(curl ifconfig.me)
-docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host galaxy/cloudman-boot


### PR DESCRIPTION
Rebased all the changes made previously for the integration, and the fixes made during GCC2019 EncoreFest.
Big changes: 1) allow for logging into Rancher with Keycloak `admin` user (and by default will be admin), and 2) add the `hostpath provisioner` fallback when running the playbook directly on a VM without a cloud provider.
Small changes: 1) bumped the Cloudman retry to 60 (as it was getting to 3 from failing before succeeding so was worried it would sometimes look like it failed although everything was successful on slower machines) and 2) added a script for building on linux but using the external IP (requires the VM to be attached to a firewall with open ports).

Tested by booting an Ubuntu with Docker VM on JetStream and running: `git clone https://github.com/almahmoud/cloudman-boot && cd cloudman-boot && git checkout keycloak_integration && sleep 5 && sudo docker build . --tag galaxy/cloudman-boot:latest && sudo sh scripts/cm_boot_public_ip_linux.sh`
Everything comes up properly. Logging in to Rancher with KeyCloak `admin` user works, and properly has admin privileges. I also created another user and tried logging in with that KeyCloak user and it properly does not allow it with message: `Logging in failed: Your account may not be authorized to log in.`
