### PR TITLE
Update Cloudman-Boot for Keycloak 7.0

### DIFF
--- a/providers/other/vars/other_vars.yml
+++ b/providers/other/vars/other_vars.yml
@@ -1,7 +1,7 @@
 ---
 rancher_name: rancher_server
 rancher_server: "{{ lookup('env', 'RANCHER_SERVER')|default(hostvars['localhost']['ansible_facts']['default_ipv4']['address'], true) }}"
-rancher_version: stable
+rancher_version: v2.2.9
 rancher_port: 4430
 rancher_port_80: 8080
 rancher_admin: admin

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -760,7 +760,7 @@
     return_content: yes
   register: kc_login_response
   until: kc_login_response['status']|default(0) == 200
-  retries: 10
+  retries: 30
   delay: 10
 
 - name: Set KeyCloak Token
@@ -873,9 +873,10 @@
   retries: 5
   delay: 10
 
+#https://rancher.com/docs/rancher/v2.x/en/admin-settings/authentication/keycloak/#keycloak-6-0-0-idpssodescriptor-missing-from-options
 - name: Get SAML Metadata IDPSSODescriptor
   uri:
-    url: "{{ kc_rancher_client_resp.location }}/installation/providers/saml-idp-descriptor"
+    url: "https://{{ rancher_server }}/auth/realms/master/protocol/saml/descriptor"
     method: GET
     validate_certs: no
     headers:
@@ -942,7 +943,7 @@
       enabled: true
       groupsField: "memberOf"
       id: "keycloak"
-      idpMetadataContent: '{{ idp_metadata.content }}'
+      idpMetadataContent: '{{ idp_metadata.content | regex_replace("<EntitiesDescriptor ([^>]*)>\s+<EntityDescriptor", "<EntityDescriptor \1") | regex_replace("\n</EntitiesDescriptor>", "") }}'
       links: { "self": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak", "update": "https://{{ rancher_server }}:{{ rancher_port }}/v3/keyCloakConfigs/keycloak" }
       name: "keycloak"
       rancherApiHost: "https://{{ rancher_server }}:{{ rancher_port }}/"

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -759,8 +759,8 @@
     validate_certs: no
     return_content: yes
   register: kc_login_response
-  until: kc_login_response['status']
-  retries: 5
+  until: kc_login_response['status']|default(0) == 200
+  retries: 10
   delay: 10
 
 - name: Set KeyCloak Token

--- a/scripts/cm_boot_linux.sh
+++ b/scripts/cm_boot_linux.sh
@@ -4,4 +4,4 @@ if [ $HOST_NAME = '--use-public-ip' ]
 then
    HOST_NAME=$(curl http://whatismyip.akamai.com)
 fi
-docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host galaxy/cloudman-boot
+docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host almahmoud/cloudman-boot:test

--- a/scripts/cm_boot_linux.sh
+++ b/scripts/cm_boot_linux.sh
@@ -4,4 +4,4 @@ if [ $HOST_NAME = '--use-public-ip' ]
 then
    HOST_NAME=$(curl http://whatismyip.akamai.com)
 fi
-docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host almahmoud/cloudman-boot:test
+docker run -v /var/run/docker.sock:/var/run/docker.sock -e "RANCHER_SERVER=$HOST_NAME" --net=host galaxy/cloudman-boot


### PR DESCRIPTION
Main changes:
- Rancher pinned to 2.2.9
- Keycloak login has longer wait (since `helm install cloudman` does not block anymore with initcontainer instead of post-install hook)
- Keycloak-Rancher integration updated for Keycloak 7.0: ref: https://rancher.com/docs/rancher/v2.x/en/admin-settings/authentication/keycloak/#keycloak-6-0-0-idpssodescriptor-missing-from-options