### PR TITLE
CVMFS-CSI added

### DIFF
--- a/roles/cloudman-boot/tasks/cloudman.yaml
+++ b/roles/cloudman-boot/tasks/cloudman.yaml
@@ -18,10 +18,6 @@
   - podmonitors.monitoring.coreos.com
   ignore_errors: true
 
-- name: Create CVMFS namespace
-  command: >
-    /usr/local/bin/kubectl create namespace cvmfs
-
 - name: Helm install CloudMan
   command: >
     /usr/local/bin/helm install cloudman galaxyproject/cloudman

--- a/roles/cloudman-boot/tasks/cvmfs.yaml
+++ b/roles/cloudman-boot/tasks/cvmfs.yaml
@@ -1,0 +1,9 @@
+- name: Create CVMFS namespace
+  command: >
+    /usr/local/bin/kubectl create namespace cvmfs
+
+- name: Helm install GALAXY-CVMFS-CSI
+  command: >
+    /usr/local/bin/helm install gxy-cvmfs galaxyproject/galaxy-cvmfs-csi
+    --namespace cvmfs
+  ignore_errors: true

--- a/roles/cloudman-boot/tasks/main.yaml
+++ b/roles/cloudman-boot/tasks/main.yaml
@@ -13,6 +13,9 @@
 - name: Setup cert-manager
   include_tasks: certmanager.yaml
 
+- name: Setup Galaxy-CVMFS-CSI
+  include_tasks: cvmfs.yaml
+
 - name: Setup CloudMan
   include_tasks: cloudman.yaml
   when: cm_skip_cloudman is not defined or not (cm_skip_cloudman|bool)


### PR DESCRIPTION
After adding NFS cache to the CVMFS-CSI and then preloading configuration files from main repository, it makes more sense to have CVMFS chart be deployed before cloudman, so that the preloading is done by the time galaxy is booted. Preloading takes about 2 minutes. With these changes and v1.3 of the CVMFS chart (https://github.com/CloudVE/helm-charts/commit/b006dbbd8d01038867fe4dea6b707b6514979b43), Galaxy launch time is down to about 3.5 minutes on the first run.
