### PR TITLE
Revert "Enable nginx metrics"

### DIFF
--- a/roles/cloudman-boot/tasks/ingress.yaml
+++ b/roles/cloudman-boot/tasks/ingress.yaml
@@ -17,8 +17,6 @@
     --set controller.kind="DaemonSet"
     --set controller.hostNetwork=true
     --set controller.daemonset.useHostPort=true
-    --set controller.metrics.enabled=true
-    --set controller.metrics.serviceMonitor.enabled=true
   ignore_errors: true
 
 - name: Fix for issue https://github.com/kubernetes/ingress-nginx/issues/5401


### PR DESCRIPTION
Reverts CloudVE/cloudman-boot#25 until prometheus operator is added else 
`Error: unable to build kubernetes objects from release manifest: unable to recognize \"\": no matches for kind \"ServiceMonitor\" in version \"monitoring.coreos.com/v1`