### PR TITLE
Doubling rke wait time

### DIFF
--- a/roles/rke/tasks/common.yaml
+++ b/roles/rke/tasks/common.yaml
@@ -87,4 +87,4 @@
   wait_for:
     path: /etc/rancher/node/password
     state: present
-    timeout: 90
+    timeout: 180


### PR DESCRIPTION
Timed out for Gulsum today, but a rerun went forward so seemed to be just a matter of having to wait longer. 3 minutes seems still reasonable