### PR TITLE
RKE version to 1.19

### DIFF
--- a/roles/rke/defaults/main.yml
+++ b/roles/rke/defaults/main.yml
@@ -15,8 +15,8 @@ random_pwd: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digi
 # Used for generating client secrets
 random_client_secret: "{{ lookup('password', '/dev/null length=8 chars=ascii_letters,digits') | lower }}-{{ lookup('password', '/dev/null length=4 chars=ascii_letters,digits') | lower }}-{{ lookup('password', '/dev/null length=4 chars=ascii_letters,digits') | lower }}-{{ lookup('password', '/dev/null length=4 chars=ascii_letters,digits') | lower }}-{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') | lower }}"
 
-rke_version: "v1.20.4+rke2r1"
-rke_container_image: "rancher/rke2-runtime:v1.20.4-rke2r1"
+rke_version: "v1.19.9+rke2r1"
+rke_container_image: "rancher/rke2-runtime:v1.19.9-rke2r1"
 rke_in_docker: "{{ lookup('env', 'RKE_IN_DOCKER') | default(false, true) }}"
 rke_registration_server: "{{ hostvars[groups['controllers'][0]]['ansible_fqdn'] | default(groups['controllers'][0]) }}"
 is_rke_registration_server: "{{ rke_registration_server == ansible_fqdn }}"


### PR DESCRIPTION
Since the current CVMFS-CSI doesn't work with 1.20, switching default back to 1.19 until we have time to resolve that