### PR TITLE
Wait for the dpkg lock to be released

### DIFF
--- a/roles/rke/tasks/system.yaml
+++ b/roles/rke/tasks/system.yaml
@@ -4,6 +4,15 @@
   ignore_errors: true
   become: yes
 
+# See https://github.com/ansible/ansible/issues/16593#issuecomment-253026793
+- name: Wait for auto-update Ubuntu does on first boot to complete.
+  become: yes
+  shell: while sudo fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1 ; do sleep 1 ; done
+  loop:
+    - lock
+    - lock.frontend
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
 - name: Update APT cache
   apt:
     update_cache: yes

--- a/roles/rke/tasks/system.yaml
+++ b/roles/rke/tasks/system.yaml
@@ -10,7 +10,7 @@
   shell: while sudo fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1 ; do sleep 1 ; done
   loop:
     - lock
-    - lock.frontend
+    - lock-frontend
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Update APT cache


### PR DESCRIPTION
Uses the [approach recommended by the Anisble developers](https://github.com/ansible/ansible/issues/16593#issuecomment-253026793) for waiting for the update Ubuntu does on first boot.

I did not include it in this PR, but after the update Ubuntu usually wants to be rebooted, so we should consider adding something like the following to the end of the play:

```
- name: Reboot Ubuntu after updates.
  reboot:
  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
```  

I can add that to this PR if needed.  Also, I notice nothing else checks if the play is running on Debian/Ubuntu so I can remove that test.
