### PR TITLE
defaultRoles removed from realm

### DIFF
--- a/roles/cloudman-boot/templates/keycloak_gvl_realm.yml.j2
+++ b/roles/cloudman-boot/templates/keycloak_gvl_realm.yml.j2
@@ -20,9 +20,6 @@ spec:
     duplicateEmailsAllowed: false
     loginTheme: "{{ cm_keycloak_theme_login }}"
     accountTheme: "{{ cm_keycloak_theme_account }}"
-    defaultRoles:
-      - offline_access
-      - uma_authorization
     users:
       - username: "admin"
         firstName: "Cloudman"


### PR DESCRIPTION
defaultRoles is supposed to be under clients, this fails verification.