### PR TITLE
Generate a kubeconfig that can be used from remote machines

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,3 +1,12 @@
+- name: Setup local filesystem
+  hosts: localhost
+  tags: ['kubeconfig']
+  tasks:
+    - name: Create outputs directory
+      file:
+        path: outputs
+        state: directory
+
 - name: Setup RKE
   hosts: rke_cluster
   roles:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,6 @@
 - name: Setup local filesystem
   hosts: localhost
-  tags: ['kubeconfig']
+  tags: [never, kubeconfig]
   tasks:
     - name: Create outputs directory
       file:

--- a/roles/rke/tasks/controller.yaml
+++ b/roles/rke/tasks/controller.yaml
@@ -56,6 +56,25 @@
     state: link
     force: true
 
+- name: Copy kubeconfig file for patching and download
+  copy:
+    src: /etc/rancher/rke2/rke2.yaml
+    dest: /tmp/rke2.yaml
+    mode: 0600
+    remote_src: yes
+
+- name: Patch the server address in the original kubeconfig
+  lineinfile:
+    path: /tmp/rke2.yaml
+    regexp: 'server: https://127\.0\.0\.1:6443'
+    line: "    server: https://{{ ansible_ssh_host }}:6443"
+
+- name: Download the kubeconfig
+  fetch:
+    src: /tmp/rke2.yaml
+    dest: outputs/{{ ansible_hostname }}.kube.config
+    flat: yes
+
 - name: Check whether kubectl exists
   shell: "which kubectl"
   register: kubectl_result

--- a/roles/rke/tasks/controller.yaml
+++ b/roles/rke/tasks/controller.yaml
@@ -56,24 +56,27 @@
     state: link
     force: true
 
-- name: Copy kubeconfig file for patching and download
-  copy:
-    src: /etc/rancher/rke2/rke2.yaml
-    dest: /tmp/rke2.yaml
-    mode: 0600
-    remote_src: yes
+- name: Get a local copy of the kubeconfig
+  tags: [ never, kubeconfig ]
+  block:
+  - name: Copy kubeconfig file for patching and download
+    copy:
+      src: /etc/rancher/rke2/rke2.yaml
+      dest: /tmp/rke2.yaml
+      mode: 0600
+      remote_src: yes
 
-- name: Patch the server address in the original kubeconfig
-  lineinfile:
-    path: /tmp/rke2.yaml
-    regexp: 'server: https://127\.0\.0\.1:6443'
-    line: "    server: https://{{ ansible_ssh_host }}:6443"
+  - name: Patch the server address in the original kubeconfig
+    lineinfile:
+      path: /tmp/rke2.yaml
+      regexp: 'server: https://127\.0\.0\.1:6443'
+      line: "    server: https://{{ ansible_ssh_host }}:6443"
 
-- name: Download the kubeconfig
-  fetch:
-    src: /tmp/rke2.yaml
-    dest: outputs/{{ ansible_hostname }}.kube.config
-    flat: yes
+  - name: Download the kubeconfig
+    fetch:
+      src: /tmp/rke2.yaml
+      dest: outputs/{{ ansible_hostname }}.kube.config
+      flat: yes
 
 - name: Check whether kubectl exists
   shell: "which kubectl"

--- a/roles/rke/templates/rke2_config.j2
+++ b/roles/rke/templates/rke2_config.j2
@@ -6,6 +6,7 @@ write-kubeconfig-mode: "0600"
 disable: rke2-ingress-nginx
 tls-san:
   - {{ cluster_hostname }}
+  - {{ ansible_ssh_host }}
 {% endif %}
 
 {% if not is_rke_registration_server %}


### PR DESCRIPTION
The certificates that are generated for the kubeconfig file are only valid for for localhost (127.0.0.1) and cannot be downloaded and used from a remote machine.  This PR adds two things to address this problem:

1. Adds `{{ ansible_ssh_host }}` to the `tls-san` section of the `rke_config.j2` template so that the certificates generated are also valid for the instance's public IP address, and
2. Downloads a copy of the kubeconfig (`/etc/rancher/rke2/rke2.yaml`) and saves it locally so it can be used to manage the cluster with `kubectl` and `helm` commands.

**Issues**

- The `kubeconfig` file is downloaded to a directory named `outputs` in the current directory on localhost.  However, no checks are performed to ensure the directory exists and no attempt is made to create the directory if it is missing.  Since creating the output directory needs to be performed on `localhost` it can't be added to the `rke` role and would have to be part of the main playbook.  Otherwise the human operator needs to ensure the directory exists before running the playbook.  One simple alternative would be to have the `outputs` directory as part of the GitHub repository so it would be created for the user when they checkout the playbook(s).

- This solution may be slightly less secure as now access is permitted to the cluster where none was allowed before.  However, this is true for SSH keys and other certificates that allow direct access to the underlying instances.  While the cluster can typically be managed through the Rancher web interface this can be problematic when it is Rancher itself that is having problems or the web interface is too slow and clunky (think satellite internet from northern Canada say...)