### PR TITLE
Generate a kubeconfig that can be used from remote machines

### DIFF
--- a/fetch.yml
+++ b/fetch.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: Create outputs directory
       file:
-        path: "{{ outputs_directory }}"
+        path: "{{ output_directory }}"
         state: directory
 
 - name: Patch and download the kubeconfig
@@ -31,7 +31,7 @@
     - name: Download the kubeconfig
       fetch:
         src: "{{ temp_file }}"
-        dest: outputs/{{ ansible_hostname }}.kube.config
+        dest: "{{ hostvars['localhost']['output_directory']}}/{{ ansible_hostname }}.kube.config"
         flat: yes
 
     - name: Cleanup the temp file

--- a/fetch.yml
+++ b/fetch.yml
@@ -1,0 +1,40 @@
+---
+# Playbook used to download a copy of the kubeconfig file from a RKE cluster.
+- name: Ensure outputs directory exists
+  hosts: localhost
+  vars:
+    output_directory: outputs
+  tasks:
+    - name: Create outputs directory
+      file:
+        path: "{{ outputs_directory }}"
+        state: directory
+
+- name: Patch and download the kubeconfig
+  hosts: controllers[0]
+  vars:
+    temp_file: /tmp/kubeconfig
+  tasks:
+    - name: Copy kubeconfig file for patching and download
+      copy:
+        src: /etc/rancher/rke2/rke2.yaml
+        dest: "{{ temp_file }}"
+        mode: 0600
+        remote_src: yes
+
+    - name: Patch the server address in the original kubeconfig
+      lineinfile:
+        path: "{{ temp_file }}"
+        regexp: 'server: https://127\.0\.0\.1:6443'
+        line: "    server: https://{{ ansible_ssh_host }}:6443"
+
+    - name: Download the kubeconfig
+      fetch:
+        src: "{{ temp_file }}"
+        dest: outputs/{{ ansible_hostname }}.kube.config
+        flat: yes
+
+    - name: Cleanup the temp file
+      file:
+        path: "{{ temp_file }}"
+        state: absent

--- a/roles/rke/templates/rke2_config.j2
+++ b/roles/rke/templates/rke2_config.j2
@@ -6,6 +6,7 @@ write-kubeconfig-mode: "0600"
 disable: rke2-ingress-nginx
 tls-san:
   - {{ cluster_hostname }}
+  - {{ ansible_ssh_host }}
 {% endif %}
 
 {% if not is_rke_registration_server %}


### PR DESCRIPTION
This replaces PR #48 

The certificates that are generated for the kubeconfig file are only valid for for localhost (127.0.0.1) and cannot be downloaded and used from a remote machine. This PR adds two things to address this problem:

1. Adds `{{ ansible_ssh_host }}` to the `tls-san` section of the `rke_config.j2` template so that the certificates generated are also valid for the instance's public IP address, and
2. Adds a new playbook (fetch.yml) that can be used to download a copy of the kubeconfig (/etc/rancher/rke2/rke2.yaml) and save it locally so it can be used to manage the cluster with kubectl and helm commands.

This PR has **not** been tested yet.