### PR TITLE
Explicitly set external url for keycloak

### DIFF
--- a/roles/cloudman-boot/templates/keycloakcrd.yml.j2
+++ b/roles/cloudman-boot/templates/keycloakcrd.yml.j2
@@ -9,6 +9,8 @@ spec:
   extensions:
     - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
     - {{ cm_keycloak_theme_url }}
+  external:
+    url: https://{{ keycloak_hostname }}
   externalAccess:
     enabled: True
     host: {{ keycloak_hostname }}


### PR DESCRIPTION
Changing the externalAccess.host in keycloak is not automatically reflected in the externalurl and ingress by the keycloak operator. Here, the externalURL is set explicitly. The ingress still has to be manually deleted but it will be recreated with the correct hostname.