### PR TITLE
Fix jetstream node adding from cloudman

### DIFF
--- a/roles/rke/templates/rke2_config.j2
+++ b/roles/rke/templates/rke2_config.j2
@@ -1,4 +1,4 @@
-node-name: "{{ ansible_hostname if 'jetstream' in kube_cloud_conf else ansible_fqdn }}"
+node-name: "{{ ansible_hostname if 'jetstream' in ansible_fqdn else ansible_fqdn }}"
 token: {{ rke_registration_token }}
 
 {% if 'controllers' in group_names %}


### PR DESCRIPTION
Node adding on jetstream was broken, because `kube_cloud_conf` is not set so the new nodes were failing to start RKE with the wrong hostname. This fixes the issue, but can have unintended consequences if the name of the node includes `jetstream` but is not actually on jetstream.