### PR TITLE
Fix Volume attachment on openstack workers

### DIFF
--- a/roles/cloudman-boot/tasks/storage.yaml
+++ b/roles/cloudman-boot/tasks/storage.yaml
@@ -3,9 +3,12 @@
     /usr/local/bin/kubectl create namespace csi-drivers
   ignore_errors: true
 
+- name: Helm add nfs-ganesha-provisioner
+  command: /usr/local/bin/helm repo add nfs-ganesha https://raw.githubusercontent.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/gh-pages
+
 - name: Helm install nfs-provisioner
   command: >
-    /usr/local/bin/helm upgrade --install nfs-provisioner stable/nfs-server-provisioner
+    /usr/local/bin/helm upgrade --install nfs-provisioner nfs-ganesha/nfs-server-provisioner
     --namespace csi-drivers
     --set persistence.enabled=true
     --set persistence.storageClass="ebs"

--- a/roles/rke/tasks/common.yaml
+++ b/roles/rke/tasks/common.yaml
@@ -88,3 +88,18 @@
     path: /etc/rancher/node/password
     state: present
     timeout: 180
+
+- name: Make sure /etc/kubernetes dir exists
+  file:
+    path: /etc/kubernetes
+    state: directory
+  become: yes
+  when: kube_cloud_provider | default(false)
+
+- name: Create cloud config in /etc/kubernetes
+  copy:
+    content: "{{ kube_cloud_conf }}"
+    dest: /etc/kubernetes/cloud-config
+  become: yes
+  when: kube_cloud_provider | default(false)
+

--- a/roles/rke/tasks/common.yaml
+++ b/roles/rke/tasks/common.yaml
@@ -28,6 +28,20 @@
   script: "set_aws_instance_tag.py '{{ cluster_hostname }}'"
   when: kube_cloud_provider == "aws"
 
+- name: Make sure /etc/kubernetes dir exists
+  file:
+    path: /etc/kubernetes
+    state: directory
+  become: yes
+  when: kube_cloud_provider | default(false)
+
+- name: Create cloud config in /etc/kubernetes
+  copy:
+    content: "{{ kube_cloud_conf }}"
+    dest: /etc/kubernetes/cloud-config
+  become: yes
+  when: kube_cloud_provider | default(false)
+
 - name: "Install rke node of type: {{ rke_node_type }} with version: {{ rke_version }}"
   shell: >-
     curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="{{ rke_version }}" INSTALL_RKE2_TYPE="{{ rke_node_type }}" sh -
@@ -88,18 +102,4 @@
     path: /etc/rancher/node/password
     state: present
     timeout: 180
-
-- name: Make sure /etc/kubernetes dir exists
-  file:
-    path: /etc/kubernetes
-    state: directory
-  become: yes
-  when: kube_cloud_provider | default(false)
-
-- name: Create cloud config in /etc/kubernetes
-  copy:
-    content: "{{ kube_cloud_conf }}"
-    dest: /etc/kubernetes/cloud-config
-  become: yes
-  when: kube_cloud_provider | default(false)
 

--- a/roles/rke/tasks/controller.yaml
+++ b/roles/rke/tasks/controller.yaml
@@ -31,19 +31,6 @@
     svc_access_line: "Login to any of these services as user 'admin', using the password you supplied."
   when: using_random_pwd is not defined
 
-- name: Make sure /etc/kubernetes dir exists
-  file:
-    path: /etc/kubernetes
-    state: directory
-  become: yes
-
-- name: Create cloud config in /etc/kubernetes
-  copy:
-    content: "{{ kube_cloud_conf }}"
-    dest: /etc/kubernetes/cloud-config
-  become: yes
-  when: kube_cloud_provider | default(false)
-
 - name: Make sure ~/.kube dir exists
   file:
     path: ~/.kube

--- a/roles/rke/templates/rke2_config.j2
+++ b/roles/rke/templates/rke2_config.j2
@@ -16,6 +16,8 @@ server: https://{{ rke_registration_server }}:9345
 cloud-provider-name: "{{ kube_cloud_provider if kube_in_tree_provider else 'external' }}"
 {% if kube_in_tree_provider %}
 cloud-provider-config: "/etc/kubernetes/cloud-config"
+{% if 'controllers' in group_names %}
 kube-controller-manager-arg: "configure-cloud-routes={{ 'true' if kube_cloud_provider == 'gce' else 'false' }}"
+{% endif %}
 {% endif %}
 {% endif %}

--- a/roles/rke/templates/rke2_config.j2
+++ b/roles/rke/templates/rke2_config.j2
@@ -12,7 +12,7 @@ tls-san:
 server: https://{{ rke_registration_server }}:9345
 {% endif %}
 
-{% if 'controllers' in group_names and kube_cloud_provider %}
+{% if kube_cloud_provider %}
 cloud-provider-name: "{{ kube_cloud_provider if kube_in_tree_provider else 'external' }}"
 {% if kube_in_tree_provider %}
 cloud-provider-config: "/etc/kubernetes/cloud-config"


### PR DESCRIPTION
Only master node was able to attach Openstack volumes, manifesting as an `AttachVolume` error event, showing a missing `/var/lib/kubelet/mounts/cinder.mounts/[...]` where `/dev/sd[a-z]+` is supposed to be mounted. Adding the `kube_cloud` config fixes it. This also needs changes to clusterman in cloudman: https://github.com/galaxyproject/cloudman/pull/153  and https://github.com/CloudVE/cloudman-helm/pull/86

Also changes deprecated NFS in favor of https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner