### PR TITLE
Cert manager 1.9.1

### DIFF
--- a/roles/cloudman-boot/tasks/certmanager.yaml
+++ b/roles/cloudman-boot/tasks/certmanager.yaml
@@ -4,7 +4,7 @@
   ignore_errors: true
 
 - name: Create cert manager CRDs
-  shell: /usr/local/bin/kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
+  shell: /usr/local/bin/kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.crds.yaml
 
 - name: Add cert manager helm repo
   shell: /usr/local/bin/helm repo add jetstack https://charts.jetstack.io
@@ -25,7 +25,7 @@
   command: >
     /usr/local/bin/helm upgrade --install cert-manager jetstack/cert-manager
     --namespace "cert-manager"
-    --version "0.11.0"
+    --version "v1.9.1"
     --set ingressShim.defaultIssuerName="letsencrypt-prod"
     --set ingressShim.defaultIssuerKind="ClusterIssuer"
     --set webhook.enabled=false

--- a/roles/cloudman-boot/templates/clusterissuer.yaml.j2
+++ b/roles/cloudman-boot/templates/clusterissuer.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod


### PR DESCRIPTION
Update to use the latest CertManager released July 22, 2022.

- Update API in the `clusterissuer.yml` template to `cert-manager.io/v1`
- Use new location of the CRDs
- Bump versions to v1.9.1

This still has to be tested.