### PR TITLE
Set nfs-ganesha chart version. Default to 1.5.0

### DIFF
--- a/roles/cloudman-boot/defaults/main.yml
+++ b/roles/cloudman-boot/defaults/main.yml
@@ -20,6 +20,8 @@ cm_cvmfs_csi_version: "{{ lookup('env', 'CM_CVMFS_CSI_VERSION') | default('2.0.0
 cm_cvmfs_csi_extra_params: "{{ lookup('env', 'CM_CVMFS_CSI_EXTRA_PARAMS') | default('', true) }}"
 # Postgres operator
 cm_postgres_operator_version: "{{ lookup('env', 'CM_POSTGRES_OPERATOR_VERSION') | default('1.9.0', true) }}"
+# NFS Provisioner
+cm_nfs_provisioner_version: "{{ lookup('env', 'CM_NFS_PROVISIONER_VERSION') | default('1.5.0', true) }}"
 
 # cluster settings
 cluster_hostname: "{{ lookup('env', 'CLUSTER_HOSTNAME') | default(inventory_hostname, true) }}"

--- a/roles/cloudman-boot/tasks/storage.yaml
+++ b/roles/cloudman-boot/tasks/storage.yaml
@@ -11,6 +11,7 @@
   command: >
     /usr/local/bin/helm upgrade --install nfs-provisioner nfs-ganesha/nfs-server-provisioner
     --namespace csi-drivers
+    --version "{{ cm_nfs_provisioner_version }}"
     --set persistence.enabled=true
     --set persistence.storageClass="ebs"
     --set persistence.size="{{ cm_initial_storage_size | default('100Gi', true) }}"


### PR DESCRIPTION
Version 1.6.0 of the NFS Ganesha provisioned updated to Ganesha to 4.0.8 [1].  Unfortunately, the image is not found.

```Failed to pull image "k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8": rpc error: code = NotFound desc = failed to pull and unpack image "k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8": failed to resolve reference "k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8": k8s.gcr.io/sig-storage/nfs-provisioner:v4.0.8: not found```

This is a known bug [2].  There is a work around (patched fork) listed in the issue.  But it might just be easier to stick with the last known working version.

References
1. https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/blob/0fa28a3bf422471851704e6192c0ea7e97489a19/CHANGELOG.md
2. https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/issues/115
