### PR TITLE
Fix OS cinder CSI

### DIFF
--- a/roles/rke/tasks/storage.yaml
+++ b/roles/rke/tasks/storage.yaml
@@ -41,13 +41,14 @@
 - name: Add OpenStack CSI Driver repo
   command: >
     /usr/local/bin/helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
-  when: kube_in_tree_provider and kube_cloud_provider == "openstack"
+  when: not kube_in_tree_provider and kube_cloud_provider == "openstack"
 
 - name: Install OpenStack CSI Driver
   command: >
     /usr/local/bin/helm upgrade --install cinder-csi cpo/openstack-cinder-csi
         --namespace csi-drivers
-  when: kube_in_tree_provider and kube_cloud_provider == "openstack"
+        --set secret.filename=cloud-config
+  when: not kube_in_tree_provider and kube_cloud_provider == "openstack"
   async: 30
   poll: 0
 


### PR DESCRIPTION
I assume the `not kube_in_tree_provider and kube_cloud_provider == "openstack"` is correct since the current default had the CSI not be installed on a Jetstream launch, and given the other cloud's CSIs, but cannot fully remember what `kube_in_tree_provider` represented tbh.


`--set secret.filename=cloud-config` is needed for the default hostPath to work, as it defaults to `cloud.conf` but we use `cloud-config` in the playbook